### PR TITLE
Paramètres pour choisir le nombre de jours à afficher dans l'agenda

### DIFF
--- a/app/services/agenda_service.ts
+++ b/app/services/agenda_service.ts
@@ -7,9 +7,8 @@ import { daysToNumberMap } from "../helpers/agenda.js";
 export class AgendaService {
 	async listEvents(userId: number) {
 		const start = DateTime.now().startOf("day");
-		const end = start.plus({ days: 14 }).endOf("day");
-
 		const today = start.toFormat("yyyy-MM-dd");
+		const windowEnd = start.plus({ days: 31 }).toFormat("yyyy-MM-dd");
 
 		const items = await AgendaItem.query()
 			.where("user_id", userId)
@@ -23,16 +22,18 @@ export class AgendaService {
 				q.whereNull("end_date").orWhere("end_date", ">=", today);
 			})
 			.andWhere((q) => {
-				// 1) Ponctuels : start_date dans la fenêtre
+				// 1) Ponctuels à venir (sans borne supérieure)
 				q.where((qq) => {
-					qq.where("recurrence_type", "once") // <-- adapte à ton slug "ponctuel"
-						.whereBetween("start_date", [start.toSQL(), end.toSQL()]);
+					qq.where("recurrence_type", "once").where("start_date", ">=", today);
 				});
 
-				// 2) Récurrents : start_date <= end
+				// 2) Récurrents : start_date <= fin de la fenêtre (31 jours)
 				q.orWhere((qq) => {
-					qq.whereNot("recurrence_type", "once") // <-- adapte
-						.where("start_date", "<=", end.toSQL());
+					qq.whereNot("recurrence_type", "once").where(
+						"start_date",
+						"<=",
+						windowEnd,
+					);
 				});
 			})
 			.orderBy("start_date", "asc");

--- a/inertia/components/agenda/agenda-item-list.tsx
+++ b/inertia/components/agenda/agenda-item-list.tsx
@@ -1,5 +1,11 @@
+import { useEffect, useState } from "react";
 import type { AgendaItem, AgendaItemOccurrence } from "#types/agenda";
-import { build14Days, normalizeEvents } from "@/utils/recurrence";
+import {
+	type AgendaView,
+	agendaViewDays,
+	getAgendaView,
+} from "@/utils/agenda_view";
+import { buildDays, normalizeEvents } from "@/utils/recurrence";
 import AgendaDay from "./agenda-day";
 import AgendaItemRow from "./agenda-item-row";
 
@@ -9,7 +15,23 @@ type Props = {
 };
 
 const AgendaItemList = ({ events, openUpdateModal }: Props) => {
-	const days = build14Days(normalizeEvents(events), new Date());
+	const [view, setView] = useState<AgendaView>("14days");
+
+	useEffect(() => {
+		setView(getAgendaView());
+
+		const onStorage = (e: StorageEvent) => {
+			if (e.key === "agenda-view") setView(getAgendaView());
+		};
+		window.addEventListener("storage", onStorage);
+		return () => window.removeEventListener("storage", onStorage);
+	}, []);
+
+	const days = buildDays(
+		normalizeEvents(events),
+		new Date(),
+		agendaViewDays(view),
+	);
 
 	return (
 		<div className="flex-1 min-h-0 overflow-y-auto pb-28">

--- a/inertia/components/layout/settings.tsx
+++ b/inertia/components/layout/settings.tsx
@@ -1,14 +1,21 @@
 import { router } from "@inertiajs/react";
-import { Moon } from "lucide-react";
+import { Calendar, Moon } from "lucide-react";
 import { useEffect, useState } from "react";
+import {
+	type AgendaView,
+	getAgendaView,
+	setAgendaView,
+} from "@/utils/agenda_view";
 import { getThemeMode, setThemeMode, type ThemeMode } from "@/utils/theme";
 import Button from "../ui/button";
 
 const Settings = () => {
 	const [theme, setTheme] = useState<ThemeMode>("system");
+	const [agendaView, setAgendaViewState] = useState<AgendaView>("14days");
 
 	useEffect(() => {
 		setTheme(getThemeMode());
+		setAgendaViewState(getAgendaView());
 	}, []);
 
 	const handleLogout = () => {
@@ -17,6 +24,44 @@ const Settings = () => {
 
 	return (
 		<div className="space-y-6 py-4">
+			<div className="space-y-4">
+				<h4 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+					AGENDA
+				</h4>
+				<div className="flex items-center justify-between">
+					<div className="flex gap-3">
+						<Calendar className="text-muted-foreground" />
+						<label
+							htmlFor="agenda-view-switch"
+							className="peer-disabled:cursor-not-allowed peer-disabled:opacity-70 text-base font-normal"
+						>
+							Période affichée
+						</label>
+					</div>
+					<select
+						id="agenda-view-switch"
+						className="bg-transparent border border-border rounded-md px-3 py-2 text-sm"
+						value={agendaView}
+						onChange={(e) => {
+							const next = e.target.value as AgendaView;
+							setAgendaViewState(next);
+							setAgendaView(next);
+						}}
+					>
+						<option className="text-black" value="14days">
+							14 jours
+						</option>
+						<option className="text-black" value="month">
+							1 mois
+						</option>
+					</select>
+				</div>
+			</div>
+			<div
+				data-orientation="horizontal"
+				role="none"
+				className="shrink-0 bg-border h-px w-full"
+			/>
 			<div className="space-y-4">
 				<h4 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
 					APPARENCE

--- a/inertia/utils/agenda_view.ts
+++ b/inertia/utils/agenda_view.ts
@@ -1,0 +1,16 @@
+export type AgendaView = "14days" | "month";
+
+const KEY = "agenda-view";
+
+export function getAgendaView(): AgendaView {
+	const v = localStorage.getItem(KEY);
+	return v === "14days" || v === "month" ? v : "14days";
+}
+
+export function setAgendaView(view: AgendaView) {
+	localStorage.setItem(KEY, view);
+}
+
+export function agendaViewDays(view: AgendaView): number {
+	return view === "month" ? 31 : 15;
+}

--- a/inertia/utils/recurrence.ts
+++ b/inertia/utils/recurrence.ts
@@ -130,54 +130,75 @@ const dayMomentOrder: Record<AgendaItem["dayMoment"], number> = {
 	evening: 2,
 };
 
-export function build14Days(
+function makeOccurrence(ev: AgendaItem, date: Date): Occurrence {
+	return {
+		key: `${dateKey(date)}-${ev.id}`,
+		date,
+		event: {
+			id: ev.id,
+			title: ev.title,
+			dayMoment: ev.dayMoment,
+			category: ev.category,
+			startDate: ev.startDate,
+			endDate: ev.endDate,
+			isPaused: ev.isPaused,
+			activePause: ev.activePause,
+			recurrence: {
+				type: ev.recurrenceType,
+				unit: ev.recurrenceUnit ? ev.recurrenceUnit : undefined,
+				interval: ev.recurrenceInterval ? ev.recurrenceInterval : undefined,
+				days: ev.weekDays ? ev.weekDays.map((d) => NumberToWeekdayMap[d]) : [],
+			},
+		},
+	};
+}
+
+export function buildDays(
 	events: AgendaItem[],
 	from = new Date(),
+	count = 15,
 ): DayBucket[] {
 	const start = startOfDay(from);
+	const windowEnd = addDays(start, count - 1);
 
-	const buckets: DayBucket[] = Array.from({ length: 15 }, (_, i) => ({
+	const buckets: DayBucket[] = Array.from({ length: count }, (_, i) => ({
 		date: addDays(start, i),
 		events: [],
 	}));
 
+	// Extra buckets for "once" events beyond the view window
+	const extraBuckets = new Map<string, DayBucket>();
+
 	for (const ev of events) {
 		for (const bucket of buckets) {
 			if (occursOnDate(ev, bucket.date)) {
-				bucket.events.push({
-					key: `${dateKey(bucket.date)}-${ev.id}`,
-					date: bucket.date,
-					event: {
-						id: ev.id,
-						title: ev.title,
-						dayMoment: ev.dayMoment,
-						category: ev.category,
-						startDate: ev.startDate,
-						endDate: ev.endDate,
-						isPaused: ev.isPaused,
-						activePause: ev.activePause,
-						recurrence: {
-							type: ev.recurrenceType,
-							unit: ev.recurrenceUnit ? ev.recurrenceUnit : undefined,
-							interval: ev.recurrenceInterval
-								? ev.recurrenceInterval
-								: undefined,
-							days: ev.weekDays
-								? ev.weekDays.map((d) => NumberToWeekdayMap[d])
-								: [],
-						},
-					},
-				});
+				bucket.events.push(makeOccurrence(ev, bucket.date));
+			}
+		}
+
+		if (ev.recurrenceType === "once") {
+			const evDay = startOfDay(ev.startDate);
+			if (evDay.getTime() > windowEnd.getTime()) {
+				const key = dateKey(evDay);
+				if (!extraBuckets.has(key)) {
+					extraBuckets.set(key, { date: evDay, events: [] });
+				}
+				const bucket = extraBuckets.get(key);
+				if (bucket) bucket.events.push(makeOccurrence(ev, evDay));
 			}
 		}
 	}
 
-	for (const bucket of buckets) {
+	const allBuckets = [...buckets, ...extraBuckets.values()].sort(
+		(a, b) => a.date.getTime() - b.date.getTime(),
+	);
+
+	for (const bucket of allBuckets) {
 		bucket.events.sort(
 			(a, b) =>
 				dayMomentOrder[a.event.dayMoment] - dayMomentOrder[b.event.dayMoment],
 		);
 	}
 
-	return buckets.filter((b) => b.events.length > 0);
+	return allBuckets.filter((b) => b.events.length > 0);
 }


### PR DESCRIPTION
## 🎯 Objectif
- Choisir combien de jours afficher dans l'agenda
- Afficher les événements de type once dans l'agenda

## 🔎 Changements
- Ajout d'un paramètre pour choisir entre 14 jours et un mois
- Affichage des événements de type once

## ✅ Checklist
- [ ] CI verte
- [ ] Tests ajoutés/ajustés si nécessaire
- [ ] Pas de breaking change (ou documenté)
- [ ] Migration/seed (si applicable)
- [ ] Docs/README à jour (si nécessaire)

## 📝 Notes
- Issue #9 