### PR TITLE
Option de réinitialisation de compteurs chaque jour

### DIFF
--- a/app/controllers/counters_controller.ts
+++ b/app/controllers/counters_controller.ts
@@ -11,6 +11,7 @@ export default class CountersController {
 	async index({ inertia, auth }: HttpContext) {
 		const { id: userId } = auth.getUserOrFail();
 		await this.counterService.applyDailyTicks(userId);
+		await this.counterService.resetDailyCounters(userId);
 		const counters = await this.counterService.index(userId);
 		return inertia.render("counters", {
 			counters,

--- a/app/services/counter_service.ts
+++ b/app/services/counter_service.ts
@@ -24,6 +24,7 @@ export class CounterService {
 			direction: payload.direction,
 			trigger: payload.trigger,
 			color: payload.color,
+			resetEachDay: payload.resetEachDay,
 		});
 	}
 
@@ -75,6 +76,25 @@ export class CounterService {
 			.andWhere("id", counterId)
 			.firstOrFail();
 		await counter.delete();
+	}
+
+	async resetDailyCounters(userId: number) {
+		const today = DateTime.now().startOf("day");
+		const counters = await Counter.query()
+			.where("user_id", userId)
+			.where("reset_each_day", true);
+
+		for (const counter of counters) {
+			const reference = counter.lastAppliedDate
+				? counter.lastAppliedDate.startOf("day")
+				: counter.createdAt.startOf("day");
+
+			if (today <= reference) continue;
+
+			counter.value = counter.initialValue;
+			counter.lastAppliedDate = today;
+			await counter.save();
+		}
 	}
 
 	async applyDailyTicks(userId: number) {

--- a/app/validators/counter.ts
+++ b/app/validators/counter.ts
@@ -12,4 +12,5 @@ export const counterValidator = vine.create({
 	direction: vine.enum([...CounterDirectionRules]),
 	trigger: vine.enum([...CounterTriggerRules]),
 	color: vine.enum([...CounterColorRules]),
+	resetEachDay: vine.boolean(),
 });

--- a/database/migrations/1772798395007_alter_counter_reset_each_days_table.ts
+++ b/database/migrations/1772798395007_alter_counter_reset_each_days_table.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+	protected tableName = "counters";
+
+	async up() {
+		this.schema.alterTable(this.tableName, (table) => {
+			table.boolean("reset_each_day").notNullable().defaultTo(false);
+		});
+	}
+
+	async down() {
+		this.schema.alterTable(this.tableName, (table) => {
+			table.dropColumn("reset_each_day");
+		});
+	}
+}

--- a/database/schema.ts
+++ b/database/schema.ts
@@ -75,7 +75,7 @@ export class AgendaItemSchema extends BaseModel {
 }
 
 export class CounterSchema extends BaseModel {
-  static $columns = ['id', 'userId', 'pinned', 'title', 'direction', 'trigger', 'initialValue', 'value', 'color', 'createdAt', 'updatedAt', 'lastAppliedDate'] as const
+  static $columns = ['id', 'userId', 'pinned', 'title', 'direction', 'trigger', 'initialValue', 'value', 'color', 'createdAt', 'updatedAt', 'lastAppliedDate', 'resetEachDay'] as const
   $columns = CounterSchema.$columns
   @column({ isPrimary: true })
   declare id: number
@@ -101,6 +101,8 @@ export class CounterSchema extends BaseModel {
   declare updatedAt: DateTime
   @column.date()
   declare lastAppliedDate: DateTime | null
+  @column()
+  declare resetEachDay: boolean
 }
 
 export class JournalSchema extends BaseModel {

--- a/database/seeders/dev_seeder.ts
+++ b/database/seeders/dev_seeder.ts
@@ -135,6 +135,7 @@ export default class extends BaseSeeder {
 				value: 3,
 				color: "streak-0",
 				lastAppliedDate: DateTime.now().startOf("day"),
+				resetEachDay: true,
 			},
 			{
 				userId: user.id,
@@ -146,6 +147,7 @@ export default class extends BaseSeeder {
 				value: 7,
 				color: "countdown-0",
 				lastAppliedDate: DateTime.now().startOf("day"),
+				resetEachDay: false,
 			},
 			{
 				userId: user.id,
@@ -157,6 +159,7 @@ export default class extends BaseSeeder {
 				value: 42,
 				color: "streak-1",
 				lastAppliedDate: DateTime.now().minus({ days: 1 }).startOf("day"),
+				resetEachDay: false,
 			},
 			{
 				userId: user.id,
@@ -168,6 +171,7 @@ export default class extends BaseSeeder {
 				value: 12,
 				color: "streak-2",
 				lastAppliedDate: DateTime.now().minus({ days: 2 }).startOf("day"),
+				resetEachDay: false,
 			},
 		]);
 

--- a/inertia/components/counter/counter-card.tsx
+++ b/inertia/components/counter/counter-card.tsx
@@ -1,6 +1,6 @@
 import { router } from "@inertiajs/react";
 import clsx from "clsx";
-import { MousePointerClick, Pencil } from "lucide-react";
+import { MousePointerClick, Pencil, RefreshCcw } from "lucide-react";
 import { type Counter, CounterColors } from "#types/counter";
 import { useModal } from "../modal/modal-context";
 import CounterForm from "./counter-form";
@@ -106,6 +106,14 @@ const CounterCard = ({ counter, showEdit = true }: Props) => {
 								<MousePointerClick size={14} /> Réinitialiser
 							</p>
 						</button>
+					)}
+					{counter.resetEachDay && (
+						<span
+							title="Réinitialisation chaque jour"
+							className="bg-white/10 px-3 flex gap-2 items-center rounded-full w-fit"
+						>
+							<RefreshCcw size={14} />
+						</span>
 					)}
 				</div>
 				{showEdit && (

--- a/inertia/components/counter/counter-form.tsx
+++ b/inertia/components/counter/counter-form.tsx
@@ -29,6 +29,7 @@ const defaultData: NewCounterFormData = {
 	trigger: "daily",
 	color: "streak-0",
 	pinned: false,
+	resetEachDay: false,
 };
 
 const CounterForm = ({
@@ -160,6 +161,11 @@ const CounterForm = ({
 				label="Épingler"
 				checked={data.pinned}
 				onChange={(v) => setData("pinned", v)}
+			/>
+			<Switch
+				label="Réinitialiser chaque jour"
+				checked={data.resetEachDay}
+				onChange={(v) => setData("resetEachDay", v)}
 			/>
 			<div className="flex flex-col-reverse md:flex-row gap-3 justify-between pt-4">
 				{mode === "update" && (

--- a/inertia/schemas/counter.schema.ts
+++ b/inertia/schemas/counter.schema.ts
@@ -13,6 +13,7 @@ export const CounterSchema = z
 		direction: z.enum(CounterDirectionRules),
 		trigger: z.enum(CounterTriggerRules),
 		color: z.enum(CounterColorRules),
+		resetEachDay: z.boolean(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.direction === "decrement" && data.value === 0) {

--- a/tests/functional/counter/counter.spec.ts
+++ b/tests/functional/counter/counter.spec.ts
@@ -36,6 +36,7 @@ const validPayload = {
 	direction: "increment",
 	trigger: "daily",
 	color: "streak-0",
+	resetEachDay: false,
 };
 
 test.group("GET /counters", (group) => {

--- a/tests/unit/counter/counter_service.spec.ts
+++ b/tests/unit/counter/counter_service.spec.ts
@@ -226,6 +226,156 @@ test.group("CounterService.applyDailyTicks", (group) => {
 	});
 });
 
+test.group("CounterService.resetDailyCounters", (group) => {
+	group.each.setup(() => testUtils.db().withGlobalTransaction());
+
+	test("ne fait rien si resetEachDay est false", async ({ assert }) => {
+		const user = await createUser();
+		const counter = await createCounter(user.id, {
+			resetEachDay: false,
+			initialValue: 0,
+			value: 7,
+		});
+
+		counter.lastAppliedDate = DateTime.now().minus({ days: 1 }).startOf("day");
+		await counter.save();
+
+		await service.resetDailyCounters(user.id);
+
+		await counter.refresh();
+		assert.equal(counter.value, 7);
+	});
+
+	test("ne fait rien si déjà réinitialisé aujourd'hui", async ({ assert }) => {
+		const user = await createUser();
+		const counter = await createCounter(user.id, {
+			resetEachDay: true,
+			initialValue: 0,
+			value: 5,
+		});
+
+		counter.lastAppliedDate = DateTime.now().startOf("day");
+		await counter.save();
+
+		await service.resetDailyCounters(user.id);
+
+		await counter.refresh();
+		assert.equal(counter.value, 5);
+	});
+
+	test("réinitialise la valeur à initialValue", async ({ assert }) => {
+		const user = await createUser();
+		const counter = await createCounter(user.id, {
+			resetEachDay: true,
+			initialValue: 3,
+			value: 9,
+		});
+
+		counter.lastAppliedDate = DateTime.now().minus({ days: 1 }).startOf("day");
+		await counter.save();
+
+		await service.resetDailyCounters(user.id);
+
+		await counter.refresh();
+		assert.equal(counter.value, 3);
+	});
+
+	test("met à jour lastAppliedDate à aujourd'hui", async ({ assert }) => {
+		const user = await createUser();
+		const counter = await createCounter(user.id, {
+			resetEachDay: true,
+			value: 4,
+		});
+
+		counter.lastAppliedDate = DateTime.now().minus({ days: 1 }).startOf("day");
+		await counter.save();
+
+		await service.resetDailyCounters(user.id);
+
+		await counter.refresh();
+		assert.equal(
+			counter.lastAppliedDate?.toFormat("yyyy-MM-dd"),
+			DateTime.now().toFormat("yyyy-MM-dd"),
+		);
+	});
+
+	test("est idempotent — double appel le même jour", async ({ assert }) => {
+		const user = await createUser();
+		const counter = await createCounter(user.id, {
+			resetEachDay: true,
+			initialValue: 0,
+			value: 8,
+		});
+
+		counter.lastAppliedDate = DateTime.now().minus({ days: 1 }).startOf("day");
+		await counter.save();
+
+		await service.resetDailyCounters(user.id);
+		await service.resetDailyCounters(user.id);
+
+		await counter.refresh();
+		assert.equal(counter.value, 0);
+	});
+
+	test("reset le lendemain de la création (lastAppliedDate null)", async ({
+		assert,
+	}) => {
+		const user = await createUser();
+		const counter = await createCounter(user.id, {
+			resetEachDay: true,
+			initialValue: 0,
+			value: 6,
+		});
+
+		counter.createdAt = DateTime.now().minus({ days: 1 }).startOf("day");
+		await counter.save();
+
+		await service.resetDailyCounters(user.id);
+
+		await counter.refresh();
+		assert.equal(counter.value, 0);
+	});
+
+	test("pas de reset si créé aujourd'hui (lastAppliedDate null)", async ({
+		assert,
+	}) => {
+		const user = await createUser();
+		const counter = await createCounter(user.id, {
+			resetEachDay: true,
+			initialValue: 0,
+			value: 5,
+		});
+		// createdAt = aujourd'hui (valeur par défaut)
+
+		await service.resetDailyCounters(user.id);
+
+		await counter.refresh();
+		assert.equal(counter.value, 5);
+	});
+
+	test("ne touche pas les compteurs d'un autre utilisateur", async ({
+		assert,
+	}) => {
+		const user = await createUser();
+		const other = await createUser();
+		const counterOther = await createCounter(other.id, {
+			resetEachDay: true,
+			initialValue: 0,
+			value: 12,
+		});
+
+		counterOther.lastAppliedDate = DateTime.now()
+			.minus({ days: 1 })
+			.startOf("day");
+		await counterOther.save();
+
+		await service.resetDailyCounters(user.id);
+
+		await counterOther.refresh();
+		assert.equal(counterOther.value, 12);
+	});
+});
+
 test.group("CounterService.createCounter", (group) => {
 	group.each.setup(() => testUtils.db().withGlobalTransaction());
 
@@ -240,6 +390,7 @@ test.group("CounterService.createCounter", (group) => {
 				direction: "increment",
 				trigger: "daily",
 				color: "streak-1",
+				resetEachDay: true,
 			},
 			user.id,
 		);

--- a/types/counter.ts
+++ b/types/counter.ts
@@ -104,6 +104,7 @@ export type NewCounterFormData = {
 	trigger: CounterTriggerSlug;
 	color: CounterColorSlug;
 	pinned: boolean;
+	resetEachDay: boolean;
 };
 
 export type CounterPayload = {
@@ -113,6 +114,7 @@ export type CounterPayload = {
 	direction: CounterDirectionSlug;
 	trigger: CounterTriggerSlug;
 	color: CounterColorSlug;
+	resetEachDay: boolean;
 };
 
 export type Counter = {
@@ -123,4 +125,5 @@ export type Counter = {
 	direction: CounterDirectionSlug;
 	trigger: CounterTriggerSlug;
 	color: CounterColorSlug;
+	resetEachDay: boolean;
 };


### PR DESCRIPTION
## 🎯 Objectif
- Pouvoir réinitialiser un compteur chaque nouveau jour

## 🔎 Changements
- Ajout d'un nouveau champs dans la table counters : resetEachDay

## ✅ Checklist
- [ ] CI verte
- [ ] Tests ajoutés/ajustés si nécessaire
- [ ] Pas de breaking change (ou documenté)
- [ ] Migration/seed (si applicable)
- [ ] Docs/README à jour (si nécessaire)

## 🧪 Comment tester
1. pnpm test